### PR TITLE
Expose abstract handler in module index (#20)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.2.0",
+  "version": "4.3.0",
   "name": "lambda-lib",
   "description": "Decorators and tools for AWS Lambda",
   "keywords": [

--- a/src/index.js
+++ b/src/index.js
@@ -5,5 +5,6 @@ export { default as Enums } from './enums'
 export { default as ApiGatewayResponse } from './api-gateway-response'
 
 export { default as HandlerController } from './handler-controller'
+export { default as AbstractHandler } from './handlers/abstract-handler'
 export { default as ApiGateway } from './handlers/api-gateway'
 export { default as Lambda } from './handlers/lambda'


### PR DESCRIPTION
In order to develop third-party handlers, we need to expose the abstract handler so it can be inherited by others.